### PR TITLE
Add integration and e2e sample tests

### DIFF
--- a/src/pages/tests/LandingPage.e2e.test.tsx
+++ b/src/pages/tests/LandingPage.e2e.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BrowserRouter } from 'react-router-dom'
+import { vi } from 'vitest'
+import LandingPage from '../LandingPage'
+import { UserContext } from '../../context/userContext'
+
+describe('LandingPage end-to-end flow', () => {
+  it('opens login modal when clicking Get Started', async () => {
+    render(
+      <BrowserRouter>
+        <UserContext.Provider value={{ user: null, loading: false, updateUser: vi.fn(), clearUser: vi.fn() }}>
+          <LandingPage />
+        </UserContext.Provider>
+      </BrowserRouter>,
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: /get started/i }))
+    expect(screen.getByText(/welcome back/i)).toBeInTheDocument()
+  })
+})

--- a/src/pages/tests/Login.test.tsx
+++ b/src/pages/tests/Login.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BrowserRouter } from 'react-router-dom'
+import { vi } from 'vitest'
+import Login from '../Auth/Login'
+import { UserContext } from '../../context/userContext'
+import { API_PATHS } from '../../utils/apiPaths'
+import axiosInstance from '../../utils/axiosInstance'
+
+vi.mock('../../utils/axiosInstance')
+
+const mockedAxios = vi.mocked(axiosInstance)
+
+describe('Login page integration', () => {
+  it('submits credentials and updates user', async () => {
+    mockedAxios.post.mockResolvedValue({ data: { token: 'token', name: 'John' } })
+    const updateUser = vi.fn()
+
+    render(
+      <BrowserRouter>
+        <UserContext.Provider value={{ user: null, loading: false, updateUser, clearUser: vi.fn() }}>
+          <Login setCurrentPage={() => {}} />
+        </UserContext.Provider>
+      </BrowserRouter>,
+    )
+
+    await userEvent.type(screen.getByPlaceholderText('john@example.com'), 'john@example.com')
+    await userEvent.type(screen.getByPlaceholderText('********'), 'pass123')
+    await userEvent.click(screen.getByRole('button', { name: /login/i }))
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(API_PATHS.AUTH.LOGIN, {
+      email: 'john@example.com',
+      password: 'pass123',
+    })
+    expect(updateUser).toHaveBeenCalledWith({ token: 'token', name: 'John' })
+  })
+})

--- a/src/utils/tests/apiPaths.test.ts
+++ b/src/utils/tests/apiPaths.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { API_PATHS } from '../apiPaths'
+
+describe('API_PATHS dynamic methods', () => {
+  it('builds GET_ONE path', () => {
+    expect(API_PATHS.SESSION.GET_ONE('123')).toBe('/api/sessions/123')
+  })
+
+  it('builds DELETE path', () => {
+    expect(API_PATHS.SESSION.DELETE('abc')).toBe('/api/sessions/abc')
+  })
+
+  it('builds QUESTION PIN path', () => {
+    expect(API_PATHS.QUESTION.PIN('id1')).toBe('/api/questions/id1/pin')
+  })
+})


### PR DESCRIPTION
## Summary
- create API path unit tests
- add integration test for login flow
- add e2e-like test for LandingPage

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68591b5f9fbc832885887c45a7d2b4df