### PR TITLE
Add missing unit tests

### DIFF
--- a/src/components/Cards/tests/ProfileInfoCard.test.tsx
+++ b/src/components/Cards/tests/ProfileInfoCard.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ProfileInfoCard from '../ProfileInfoCard'
+import { UserContext } from '../../../context/userContext'
+import { vi } from 'vitest'
+import { useNavigate } from 'react-router-dom'
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<any>('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: vi.fn(),
+  }
+})
+
+const navigateMock = vi.fn()
+;(useNavigate as unknown as vi.Mock).mockReturnValue(navigateMock)
+
+const renderWithContext = (value: any) =>
+  render(
+    <UserContext.Provider value={value}>
+      <ProfileInfoCard />
+    </UserContext.Provider>,
+  )
+
+describe('ProfileInfoCard', () => {
+  it('returns null when no user is provided', () => {
+    const { container } = renderWithContext({ user: null, loading: false, updateUser: vi.fn(), clearUser: vi.fn() })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('displays user info and handles logout', async () => {
+    const clearUser = vi.fn()
+    const user = { name: 'Jane', profileImageUrl: 'img.png', token: 't' }
+    renderWithContext({ user, loading: false, updateUser: vi.fn(), clearUser })
+
+    expect(screen.getByText('Jane')).toBeInTheDocument()
+
+    const clearSpy = vi.spyOn(window.localStorage.__proto__, 'clear')
+    await userEvent.click(screen.getByRole('button', { name: /logout/i }))
+
+    expect(clearSpy).toHaveBeenCalled()
+    expect(clearUser).toHaveBeenCalled()
+    expect(navigateMock).toHaveBeenCalledWith('/')
+
+    clearSpy.mockRestore()
+  })
+})

--- a/src/components/Cards/tests/QuestionCard.test.tsx
+++ b/src/components/Cards/tests/QuestionCard.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import QuestionCard from '../QuestionCard'
+import { vi } from 'vitest'
+
+vi.mock('../../../pages/InterviewPrep/components/AiResponsePreview', () => ({
+  default: ({ content }: { content: string }) => <div>{content}</div>,
+}))
+
+describe('QuestionCard', () => {
+  const baseProps = {
+    question: 'What is React?',
+    answer: 'Library',
+    onLearnMore: vi.fn(),
+    isPinned: false,
+    onTogglePin: vi.fn(),
+  }
+
+  it('toggles expansion when question clicked', async () => {
+    render(<QuestionCard {...baseProps} />)
+    const btn = screen.getByRole('button', { name: 'What is React?' })
+    await userEvent.click(btn)
+    expect(screen.getByText('Library')).toBeInTheDocument()
+  })
+
+  it('calls onTogglePin when pin clicked', async () => {
+    const onTogglePin = vi.fn()
+    render(<QuestionCard {...baseProps} onTogglePin={onTogglePin} />)
+    const pinBtn = screen.getAllByRole('button')[1]
+    await userEvent.click(pinBtn)
+    expect(onTogglePin).toHaveBeenCalled()
+  })
+
+  it('calls onLearnMore when learn more clicked', async () => {
+    const onLearnMore = vi.fn()
+    render(<QuestionCard {...baseProps} onLearnMore={onLearnMore} />)
+    const learnBtn = screen.getByText(/learn more/i)
+    await userEvent.click(learnBtn)
+    expect(onLearnMore).toHaveBeenCalled()
+  })
+})

--- a/src/components/Cards/tests/SummaryCard.test.tsx
+++ b/src/components/Cards/tests/SummaryCard.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SummaryCard from '../SummaryCard'
+import { vi } from 'vitest'
+
+const baseProps = {
+  colors: { bgcolor: 'red' },
+  role: 'Frontend Dev',
+  topicToFocus: 'React',
+  experience: 2,
+  questions: 5,
+  description: 'desc',
+  lastUpdated: 'today',
+}
+
+describe('SummaryCard', () => {
+  it('calls onSelect when card clicked', async () => {
+    const onSelect = vi.fn()
+    render(<SummaryCard {...baseProps} onSelect={onSelect} onDelete={vi.fn()} />)
+    await userEvent.click(screen.getByText('Frontend Dev'))
+    expect(onSelect).toHaveBeenCalled()
+  })
+
+  it('calls onDelete without triggering onSelect', async () => {
+    const onDelete = vi.fn()
+    const onSelect = vi.fn()
+    render(<SummaryCard {...baseProps} onSelect={onSelect} onDelete={onDelete} />)
+    await userEvent.click(screen.getByRole('button'))
+    expect(onDelete).toHaveBeenCalled()
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('displays initials from role', () => {
+    render(<SummaryCard {...baseProps} onSelect={vi.fn()} onDelete={vi.fn()} />)
+    expect(screen.getByText('FD')).toBeInTheDocument()
+  })
+})

--- a/src/components/Inputs/tests/ProfilePhotoSelector.test.tsx
+++ b/src/components/Inputs/tests/ProfilePhotoSelector.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ProfilePhotoSelector from '../ProfilePhotoSelector'
+import { vi } from 'vitest'
+
+// jsdom doesn't implement createObjectURL
+(global as any).URL.createObjectURL = vi.fn(() => 'blob:url')
+
+describe('ProfilePhotoSelector', () => {
+  it('opens file dialog when upload button clicked', async () => {
+    const setImage = vi.fn()
+    const { container } = render(<ProfilePhotoSelector image={null} setImage={setImage} />)
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    const clickSpy = vi.spyOn(input, 'click')
+    await userEvent.click(screen.getByRole('button'))
+    expect(clickSpy).toHaveBeenCalled()
+  })
+
+  it('handles image upload and removal', async () => {
+    const setImage = vi.fn()
+    const file = new File(['1'], 'a.png', { type: 'image/png' })
+    const { container, rerender } = render(
+      <ProfilePhotoSelector image={null} setImage={setImage} />,
+    )
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    await userEvent.upload(input, file)
+    expect(setImage).toHaveBeenCalledWith(file)
+
+    rerender(<ProfilePhotoSelector image={file} setImage={setImage} preview="blob:url" />)
+    await userEvent.click(screen.getByRole('button'))
+    expect(setImage).toHaveBeenCalledWith(null)
+  })
+})

--- a/src/components/Loader/tests/SkeletonLoader.test.tsx
+++ b/src/components/Loader/tests/SkeletonLoader.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react'
+import SkeletonLoader from '../SkeletonLoader'
+
+describe('SkeletonLoader', () => {
+  it('renders with status role', () => {
+    render(<SkeletonLoader />)
+    expect(screen.getAllByRole('status').length).toBeGreaterThan(0)
+  })
+})

--- a/src/components/Loader/tests/SpinnerLoader.test.tsx
+++ b/src/components/Loader/tests/SpinnerLoader.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react'
+import SpinnerLoader from '../SpinnerLoader'
+
+describe('SpinnerLoader', () => {
+  it('renders spinner svg', () => {
+    render(<SpinnerLoader />)
+    expect(screen.getByRole('status')).toBeInTheDocument()
+  })
+})

--- a/src/components/layouts/tests/DashboardLayout.test.tsx
+++ b/src/components/layouts/tests/DashboardLayout.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import DashboardLayout from '../DashboardLayout'
+import { UserContext } from '../../../context/userContext'
+import { vi } from 'vitest'
+
+vi.mock('../Navbar', () => ({ default: () => <div>nav</div> }))
+
+const renderWithUser = (user: any) =>
+  render(
+    <UserContext.Provider value={{ user, loading: false, updateUser: vi.fn(), clearUser: vi.fn() }}>
+      <DashboardLayout>
+        <div>child</div>
+      </DashboardLayout>
+    </UserContext.Provider>,
+  )
+
+describe('DashboardLayout', () => {
+  it('shows children when user exists', () => {
+    renderWithUser({ token: 't' })
+    expect(screen.getByText('child')).toBeInTheDocument()
+  })
+
+  it('hides children when no user', () => {
+    const { queryByText } = renderWithUser(null)
+    expect(queryByText('child')).toBeNull()
+  })
+})

--- a/src/components/layouts/tests/Navbar.test.tsx
+++ b/src/components/layouts/tests/Navbar.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react'
+import Navbar from '../Navbar'
+import { MemoryRouter } from 'react-router-dom'
+
+vi.mock('../../Cards/ProfileInfoCard', () => ({
+  default: () => <div>profile</div>,
+}))
+
+describe('Navbar', () => {
+  it('renders link and profile info', () => {
+    render(
+      <MemoryRouter>
+        <Navbar />
+      </MemoryRouter>,
+    )
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/dashboard')
+    expect(screen.getByText('profile')).toBeInTheDocument()
+  })
+})

--- a/src/utils/tests/UploadImage.test.ts
+++ b/src/utils/tests/UploadImage.test.ts
@@ -1,0 +1,21 @@
+import uploadImage from '../UploadImage'
+import { API_PATHS } from '../apiPaths'
+import axiosInstance from '../axiosInstance'
+import { vi } from 'vitest'
+
+vi.mock('../axiosInstance')
+
+const mockedAxios = vi.mocked(axiosInstance)
+
+describe('uploadImage', () => {
+  it('posts form data to upload endpoint', async () => {
+    mockedAxios.post.mockResolvedValue({ data: 'ok' })
+    const file = new File(['1'], 'a.png', { type: 'image/png' })
+    const data = await uploadImage(file)
+    expect(mockedAxios.post).toHaveBeenCalled()
+    const call = mockedAxios.post.mock.calls[0]
+    expect(call[0]).toBe(API_PATHS.IMAGE.UPLOAD_IMAGE)
+    expect(call[1] instanceof FormData).toBe(true)
+    expect(data).toBe('ok')
+  })
+})


### PR DESCRIPTION
## Summary
- add tests for card components: ProfileInfoCard, SummaryCard and QuestionCard
- cover ProfilePhotoSelector input behavior
- test layout components and loaders
- add unit test for UploadImage utility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685927201318832899c0cfd9f6937d1b