### PR TITLE
Add Cypress E2E tests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'cypress'
+
+export default defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:5173',
+    supportFile: false,
+  },
+})

--- a/cypress/e2e/createSession.cy.ts
+++ b/cypress/e2e/createSession.cy.ts
@@ -1,0 +1,26 @@
+describe('Create session flow', () => {
+  beforeEach(() => {
+    localStorage.setItem('token', 'abc')
+    cy.intercept('GET', '/api/sessions/my-sessions', { sessions: [] })
+    cy.visit('/dashboard')
+    cy.contains('Add New').click()
+  })
+
+  it('submits session data and navigates to interview page', () => {
+    cy.intercept('POST', '/api/ai/generate-questions', { statusCode: 200, body: [] }).as('gen')
+    cy.intercept('POST', '/api/sessions/create', {
+      statusCode: 200,
+      body: { session: { _id: '123' } },
+    }).as('create')
+
+    cy.get('input[placeholder="e.g., Frontend Developer, UI/UX Designer, etc."]').type('Frontend Developer')
+    cy.get('input[placeholder="e.g., 1 year, 3 years, 5+ years"]').type('1')
+    cy.get('input[placeholder="e.g., React, CSS, Algorithms, etc."]').type('React')
+    cy.get('input[placeholder="e.g., I want to focus on React and CSS."]').type('desc')
+    cy.contains('button', 'Create Session').click()
+
+    cy.wait('@gen')
+    cy.wait('@create')
+    cy.url().should('include', '/interview-prep/123')
+  })
+})

--- a/cypress/e2e/dashboard.cy.ts
+++ b/cypress/e2e/dashboard.cy.ts
@@ -1,0 +1,25 @@
+describe('Dashboard page', () => {
+  beforeEach(() => {
+    localStorage.setItem('token', 'abc')
+    cy.intercept('GET', '/api/sessions/my-sessions', {
+      sessions: [
+        {
+          _id: '1',
+          role: 'Developer',
+          experience: '1',
+          topicToFocus: 'React',
+          description: 'desc',
+          questions: [],
+          updatedAt: '2024-06-01',
+        },
+      ],
+    }).as('getSessions')
+  })
+
+  it('loads sessions and opens create form', () => {
+    cy.visit('/dashboard')
+    cy.wait('@getSessions')
+    cy.contains('Add New').click()
+    cy.get('input[placeholder="e.g., Frontend Developer, UI/UX Designer, etc."]').should('be.visible')
+  })
+})

--- a/cypress/e2e/interviewPrep.cy.ts
+++ b/cypress/e2e/interviewPrep.cy.ts
@@ -1,0 +1,36 @@
+describe('Interview preparation page', () => {
+  beforeEach(() => {
+    localStorage.setItem('token', 'abc')
+    cy.intercept('GET', '/api/sessions/1', {
+      session: {
+        _id: '1',
+        role: 'Dev',
+        experience: '1',
+        topicToFocus: 'React',
+        description: 'desc',
+        updatedAt: '2024-06-01',
+        questions: [
+          {
+            _id: 'q1',
+            question: 'Why React?',
+            answer: 'Because',
+            isPinned: false,
+          },
+        ],
+      },
+    }).as('getSession')
+  })
+
+  it('shows explanation drawer', () => {
+    cy.intercept('POST', '/api/ai/generate-explanations', {
+      title: 'Explain',
+      explanation: 'Some explanation',
+    }).as('explain')
+
+    cy.visit('/interview-prep/1')
+    cy.wait('@getSession')
+    cy.contains('Why React?').parent().find('button').contains(/learn more/i).click({ force: true })
+    cy.wait('@explain')
+    cy.contains('Explain').should('be.visible')
+  })
+})

--- a/cypress/e2e/signup.cy.ts
+++ b/cypress/e2e/signup.cy.ts
@@ -1,0 +1,20 @@
+describe('Sign up flow', () => {
+  it('submits form and redirects to dashboard', () => {
+    cy.intercept('POST', '/api/auth/register', {
+      statusCode: 200,
+      body: { token: 'abc', name: 'Jane' },
+    }).as('register')
+
+    cy.visit('/')
+    cy.contains('Login / Sign Up').click()
+    cy.contains('Sign Up').click()
+
+    cy.get('input[placeholder="John Doe"]').type('Jane Doe')
+    cy.get('input[placeholder="john@example.com"]').type('jane@example.com')
+    cy.get('input[placeholder="********"]').type('pass')
+
+    cy.contains('button', /sign up/i).click()
+    cy.wait('@register')
+    cy.url().should('include', '/dashboard')
+  })
+})

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.node.json",
+  "compilerOptions": {
+    "types": ["cypress"]
+  },
+  "include": ["./**/*.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,8 @@
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
         "vite": "^6.3.5",
-        "vitest": "^3.2.3"
+        "vitest": "^3.2.3",
+        "cypress": "^13.7.3"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest",
-    "test:watch": "vitest --watch"
+    "test:watch": "vitest --watch",
+    "test:e2e": "cypress run"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.6",
@@ -44,6 +45,7 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
     "vite": "^6.3.5",
-    "vitest": "^3.2.3"
+    "vitest": "^3.2.3",
+    "cypress": "^13.7.3"
   }
 }

--- a/src/components/Cards/tests/ProfileInfoCard.test.tsx
+++ b/src/components/Cards/tests/ProfileInfoCard.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ProfileInfoCard from '../ProfileInfoCard'
+import { UserContext } from '../../../context/userContext'
+import { vi } from 'vitest'
+import { useNavigate } from 'react-router-dom'
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<any>('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: vi.fn(),
+  }
+})
+
+const navigateMock = vi.fn()
+;(useNavigate as unknown as vi.Mock).mockReturnValue(navigateMock)
+
+const renderWithContext = (value: any) =>
+  render(
+    <UserContext.Provider value={value}>
+      <ProfileInfoCard />
+    </UserContext.Provider>,
+  )
+
+describe('ProfileInfoCard', () => {
+  it('returns null when no user is provided', () => {
+    const { container } = renderWithContext({ user: null, loading: false, updateUser: vi.fn(), clearUser: vi.fn() })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('displays user info and handles logout', async () => {
+    const clearUser = vi.fn()
+    const user = { name: 'Jane', profileImageUrl: 'img.png', token: 't' }
+    renderWithContext({ user, loading: false, updateUser: vi.fn(), clearUser })
+
+    expect(screen.getByText('Jane')).toBeInTheDocument()
+
+    const clearSpy = vi.spyOn(window.localStorage.__proto__, 'clear')
+    await userEvent.click(screen.getByRole('button', { name: /logout/i }))
+
+    expect(clearSpy).toHaveBeenCalled()
+    expect(clearUser).toHaveBeenCalled()
+    expect(navigateMock).toHaveBeenCalledWith('/')
+
+    clearSpy.mockRestore()
+  })
+})

--- a/src/components/Cards/tests/QuestionCard.test.tsx
+++ b/src/components/Cards/tests/QuestionCard.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import QuestionCard from '../QuestionCard'
+import { vi } from 'vitest'
+
+vi.mock('../../../pages/InterviewPrep/components/AiResponsePreview', () => ({
+  default: ({ content }: { content: string }) => <div>{content}</div>,
+}))
+
+describe('QuestionCard', () => {
+  const baseProps = {
+    question: 'What is React?',
+    answer: 'Library',
+    onLearnMore: vi.fn(),
+    isPinned: false,
+    onTogglePin: vi.fn(),
+  }
+
+  it('toggles expansion when question clicked', async () => {
+    render(<QuestionCard {...baseProps} />)
+    const btn = screen.getByRole('button', { name: 'What is React?' })
+    await userEvent.click(btn)
+    expect(screen.getByText('Library')).toBeInTheDocument()
+  })
+
+  it('calls onTogglePin when pin clicked', async () => {
+    const onTogglePin = vi.fn()
+    render(<QuestionCard {...baseProps} onTogglePin={onTogglePin} />)
+    const pinBtn = screen.getAllByRole('button')[1]
+    await userEvent.click(pinBtn)
+    expect(onTogglePin).toHaveBeenCalled()
+  })
+
+  it('calls onLearnMore when learn more clicked', async () => {
+    const onLearnMore = vi.fn()
+    render(<QuestionCard {...baseProps} onLearnMore={onLearnMore} />)
+    const learnBtn = screen.getByText(/learn more/i)
+    await userEvent.click(learnBtn)
+    expect(onLearnMore).toHaveBeenCalled()
+  })
+})

--- a/src/components/Cards/tests/SummaryCard.test.tsx
+++ b/src/components/Cards/tests/SummaryCard.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SummaryCard from '../SummaryCard'
+import { vi } from 'vitest'
+
+const baseProps = {
+  colors: { bgcolor: 'red' },
+  role: 'Frontend Dev',
+  topicToFocus: 'React',
+  experience: 2,
+  questions: 5,
+  description: 'desc',
+  lastUpdated: 'today',
+}
+
+describe('SummaryCard', () => {
+  it('calls onSelect when card clicked', async () => {
+    const onSelect = vi.fn()
+    render(<SummaryCard {...baseProps} onSelect={onSelect} onDelete={vi.fn()} />)
+    await userEvent.click(screen.getByText('Frontend Dev'))
+    expect(onSelect).toHaveBeenCalled()
+  })
+
+  it('calls onDelete without triggering onSelect', async () => {
+    const onDelete = vi.fn()
+    const onSelect = vi.fn()
+    render(<SummaryCard {...baseProps} onSelect={onSelect} onDelete={onDelete} />)
+    await userEvent.click(screen.getByRole('button'))
+    expect(onDelete).toHaveBeenCalled()
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('displays initials from role', () => {
+    render(<SummaryCard {...baseProps} onSelect={vi.fn()} onDelete={vi.fn()} />)
+    expect(screen.getByText('FD')).toBeInTheDocument()
+  })
+})

--- a/src/components/Inputs/tests/ProfilePhotoSelector.test.tsx
+++ b/src/components/Inputs/tests/ProfilePhotoSelector.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ProfilePhotoSelector from '../ProfilePhotoSelector'
+import { vi } from 'vitest'
+
+// jsdom doesn't implement createObjectURL
+(global as any).URL.createObjectURL = vi.fn(() => 'blob:url')
+
+describe('ProfilePhotoSelector', () => {
+  it('opens file dialog when upload button clicked', async () => {
+    const setImage = vi.fn()
+    const { container } = render(<ProfilePhotoSelector image={null} setImage={setImage} />)
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    const clickSpy = vi.spyOn(input, 'click')
+    await userEvent.click(screen.getByRole('button'))
+    expect(clickSpy).toHaveBeenCalled()
+  })
+
+  it('handles image upload and removal', async () => {
+    const setImage = vi.fn()
+    const file = new File(['1'], 'a.png', { type: 'image/png' })
+    const { container, rerender } = render(
+      <ProfilePhotoSelector image={null} setImage={setImage} />,
+    )
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    await userEvent.upload(input, file)
+    expect(setImage).toHaveBeenCalledWith(file)
+
+    rerender(<ProfilePhotoSelector image={file} setImage={setImage} preview="blob:url" />)
+    await userEvent.click(screen.getByRole('button'))
+    expect(setImage).toHaveBeenCalledWith(null)
+  })
+})

--- a/src/components/Loader/tests/SkeletonLoader.test.tsx
+++ b/src/components/Loader/tests/SkeletonLoader.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react'
+import SkeletonLoader from '../SkeletonLoader'
+
+describe('SkeletonLoader', () => {
+  it('renders with status role', () => {
+    render(<SkeletonLoader />)
+    expect(screen.getAllByRole('status').length).toBeGreaterThan(0)
+  })
+})

--- a/src/components/Loader/tests/SpinnerLoader.test.tsx
+++ b/src/components/Loader/tests/SpinnerLoader.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react'
+import SpinnerLoader from '../SpinnerLoader'
+
+describe('SpinnerLoader', () => {
+  it('renders spinner svg', () => {
+    render(<SpinnerLoader />)
+    expect(screen.getByRole('status')).toBeInTheDocument()
+  })
+})

--- a/src/components/layouts/tests/DashboardLayout.test.tsx
+++ b/src/components/layouts/tests/DashboardLayout.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import DashboardLayout from '../DashboardLayout'
+import { UserContext } from '../../../context/userContext'
+import { vi } from 'vitest'
+
+vi.mock('../Navbar', () => ({ default: () => <div>nav</div> }))
+
+const renderWithUser = (user: any) =>
+  render(
+    <UserContext.Provider value={{ user, loading: false, updateUser: vi.fn(), clearUser: vi.fn() }}>
+      <DashboardLayout>
+        <div>child</div>
+      </DashboardLayout>
+    </UserContext.Provider>,
+  )
+
+describe('DashboardLayout', () => {
+  it('shows children when user exists', () => {
+    renderWithUser({ token: 't' })
+    expect(screen.getByText('child')).toBeInTheDocument()
+  })
+
+  it('hides children when no user', () => {
+    const { queryByText } = renderWithUser(null)
+    expect(queryByText('child')).toBeNull()
+  })
+})

--- a/src/components/layouts/tests/Navbar.test.tsx
+++ b/src/components/layouts/tests/Navbar.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react'
+import Navbar from '../Navbar'
+import { MemoryRouter } from 'react-router-dom'
+
+vi.mock('../../Cards/ProfileInfoCard', () => ({
+  default: () => <div>profile</div>,
+}))
+
+describe('Navbar', () => {
+  it('renders link and profile info', () => {
+    render(
+      <MemoryRouter>
+        <Navbar />
+      </MemoryRouter>,
+    )
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/dashboard')
+    expect(screen.getByText('profile')).toBeInTheDocument()
+  })
+})

--- a/src/pages/tests/CreateSessionForm.test.tsx
+++ b/src/pages/tests/CreateSessionForm.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { vi } from 'vitest'
+
+import CreateSessionForm from '../Home/CreateSessionFrom'
+import axiosInstance from '../../utils/axiosInstance'
+import { API_PATHS } from '../../utils/apiPaths'
+
+vi.mock('../../utils/axiosInstance')
+vi.mock('../../components/Loader/SpinnerLoader', () => ({ default: () => <div>load</div> }))
+
+const navigateMock = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual: any = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => navigateMock }
+})
+
+const mockedAxios = vi.mocked(axiosInstance)
+
+describe('CreateSessionForm integration', () => {
+  it('creates session and navigates', async () => {
+    mockedAxios.post
+      .mockResolvedValueOnce({ data: [{ question: 'Q1', answer: 'A1' }] })
+      .mockResolvedValueOnce({ data: { session: { _id: '10' } } })
+
+    render(
+      <MemoryRouter>
+        <CreateSessionForm />
+      </MemoryRouter>,
+    )
+
+    await userEvent.type(screen.getByPlaceholderText('e.g., Frontend Developer, UI/UX Designer, etc.'), 'FE')
+    await userEvent.type(screen.getByPlaceholderText('e.g., 1 year, 3 years, 5+ years'), '2')
+    await userEvent.type(screen.getByPlaceholderText('e.g., React, CSS, Algorithms, etc.'), 'React')
+    await userEvent.type(screen.getByPlaceholderText('e.g., I want to focus on React and CSS.'), 'desc')
+    await userEvent.click(screen.getByRole('button', { name: /create session/i }))
+
+    expect(mockedAxios.post).toHaveBeenNthCalledWith(1, API_PATHS.AI.GENERATE_QUESTIONS, expect.objectContaining({
+      role: 'FE',
+      experience: '2',
+      topicToFocus: 'React',
+      numberOfQuestions: 10,
+    }))
+    expect(mockedAxios.post).toHaveBeenNthCalledWith(2, API_PATHS.SESSION.CREATE, expect.objectContaining({
+      role: 'FE',
+      experience: '2',
+      topicToFocus: 'React',
+      description: 'desc',
+    }))
+    expect(navigateMock).toHaveBeenCalledWith('/interview-prep/10')
+  })
+})

--- a/src/pages/tests/Dashboard.test.tsx
+++ b/src/pages/tests/Dashboard.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { vi } from 'vitest'
+
+import Dashboard from '../Home/Dashboard'
+import { UserContext } from '../../context/userContext'
+import axiosInstance from '../../utils/axiosInstance'
+import { API_PATHS } from '../../utils/apiPaths'
+
+vi.mock('../../utils/axiosInstance')
+vi.mock('../../components/layouts/Navbar', () => ({ default: () => <div>nav</div> }))
+vi.mock('../Home/CreateSessionFrom', () => ({ default: () => <div>form</div> }))
+vi.mock('../../components/Modal', () => ({
+  default: ({ isOpen, children }: any) => (isOpen ? <div data-testid='modal'>{children}</div> : null),
+}))
+vi.mock('../../components/Cards/SummaryCard', () => ({
+  default: ({ role, onSelect, onDelete }: any) => (
+    <div onClick={onSelect}>
+      <span>{role}</span>
+      <button onClick={e => { e.stopPropagation(); onDelete() }}>delete</button>
+    </div>
+  ),
+}))
+
+const navigateMock = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual: any = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => navigateMock }
+})
+
+const mockedAxios = vi.mocked(axiosInstance)
+
+describe('Dashboard page integration', () => {
+  it('fetches sessions and handles interactions', async () => {
+    mockedAxios.get.mockResolvedValue({ data: { sessions: [{ _id: '1', role: 'FE', topicToFocus: 'React', experience: 1, questions: [], description: 'desc', updatedAt: '' }] } })
+
+    render(
+      <MemoryRouter>
+        <UserContext.Provider value={{ user: { token: 't' }, loading: false, updateUser: vi.fn(), clearUser: vi.fn() }}>
+          <Dashboard />
+        </UserContext.Provider>
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText('FE')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /add new/i }))
+    expect(screen.getByTestId('modal')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByText('FE'))
+    expect(navigateMock).toHaveBeenCalledWith('/interview-prep/1')
+  })
+})

--- a/src/pages/tests/InterviewPrep.test.tsx
+++ b/src/pages/tests/InterviewPrep.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { vi } from 'vitest'
+
+import InterviewPrep from '../InterviewPrep/InterviewPrep'
+import { UserContext } from '../../context/userContext'
+import axiosInstance from '../../utils/axiosInstance'
+import { API_PATHS } from '../../utils/apiPaths'
+
+vi.mock('../../utils/axiosInstance')
+vi.mock('../../components/layouts/Navbar', () => ({ default: () => <div>nav</div> }))
+vi.mock('../InterviewPrep/components/AiResponsePreview', () => ({ default: ({ content }: any) => <div>{content}</div> }))
+
+const mockedAxios = vi.mocked(axiosInstance)
+
+describe('InterviewPrep page integration', () => {
+  it('loads session and shows explanation drawer', async () => {
+    mockedAxios.get.mockResolvedValue({ data: { session: {
+      _id: '1',
+      role: 'FE',
+      topicToFocus: 'React',
+      experience: '2',
+      description: 'desc',
+      updatedAt: '',
+      questions: [{ _id: 'q1', question: 'Q1', answer: 'A1', isPinned: false }],
+    } } })
+    mockedAxios.post.mockResolvedValue({ data: { title: 'Title', explanation: 'Exp' } })
+
+    render(
+      <MemoryRouter initialEntries={['/interview-prep/1']}>
+        <UserContext.Provider value={{ user: { token: 't' }, loading: false, updateUser: vi.fn(), clearUser: vi.fn() }}>
+          <Routes>
+            <Route path='/interview-prep/:sessionId' element={<InterviewPrep />} />
+          </Routes>
+        </UserContext.Provider>
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText('Q1')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByText(/learn more/i))
+    expect(mockedAxios.post).toHaveBeenCalledWith(API_PATHS.AI.GENERATE_EXPLANATION, { question: 'Q1' })
+    expect(await screen.findByText('Exp')).toBeInTheDocument()
+  })
+})

--- a/src/pages/tests/LandingPage.test.tsx
+++ b/src/pages/tests/LandingPage.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { vi } from 'vitest'
+
+import LandingPage from '../LandingPage'
+import { UserContext } from '../../context/userContext'
+
+vi.mock('../Auth/Login', () => ({ default: () => <div>login</div> }))
+vi.mock('../Auth/SignUp', () => ({ default: () => <div>signup</div> }))
+vi.mock('../../components/Modal', () => ({
+  default: ({ isOpen, children }: any) => (isOpen ? <div data-testid='modal'>{children}</div> : null),
+}))
+vi.mock('../../components/Cards/ProfileInfoCard', () => ({ default: () => <div>profile</div> }))
+
+const navigateMock = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual: any = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => navigateMock }
+})
+
+describe('LandingPage integration', () => {
+  it('opens auth modal when unauthenticated', async () => {
+    render(
+      <MemoryRouter>
+        <UserContext.Provider value={{ user: null, loading: false, updateUser: vi.fn(), clearUser: vi.fn() }}>
+          <LandingPage />
+        </UserContext.Provider>
+      </MemoryRouter>,
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: /get started/i }))
+    expect(screen.getByTestId('modal')).toBeInTheDocument()
+  })
+
+  it('navigates to dashboard when user exists', async () => {
+    render(
+      <MemoryRouter>
+        <UserContext.Provider value={{ user: { token: 't' }, loading: false, updateUser: vi.fn(), clearUser: vi.fn() }}>
+          <LandingPage />
+        </UserContext.Provider>
+      </MemoryRouter>,
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: /get started/i }))
+    expect(navigateMock).toHaveBeenCalledWith('/dashboard')
+  })
+})

--- a/src/pages/tests/SignUp.test.tsx
+++ b/src/pages/tests/SignUp.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BrowserRouter } from 'react-router-dom'
+import { vi } from 'vitest'
+
+import SignUp from '../Auth/SignUp'
+import { UserContext } from '../../context/userContext'
+import axiosInstance from '../../utils/axiosInstance'
+import { API_PATHS } from '../../utils/apiPaths'
+import uploadImage from '../../utils/UploadImage'
+
+vi.mock('../../utils/axiosInstance')
+vi.mock('../../utils/UploadImage')
+vi.mock('../../components/Inputs/ProfilePhotoSelector', () => ({
+  default: ({ setImage }: any) => (
+    <input type="file" data-testid="photo-input" onChange={e => setImage(e.target.files?.[0] ?? null)} />
+  ),
+}))
+
+const mockedAxios = vi.mocked(axiosInstance)
+const mockedUpload = vi.mocked(uploadImage)
+
+describe('SignUp page integration', () => {
+  it('submits form data and updates user', async () => {
+    mockedAxios.post.mockResolvedValue({ data: { token: 't', name: 'Jane' } })
+    const updateUser = vi.fn()
+
+    render(
+      <BrowserRouter>
+        <UserContext.Provider value={{ user: null, loading: false, updateUser, clearUser: vi.fn() }}>
+          <SignUp setCurrentPage={() => {}} />
+        </UserContext.Provider>
+      </BrowserRouter>,
+    )
+
+    await userEvent.type(screen.getByPlaceholderText('John Doe'), 'Jane Doe')
+    await userEvent.type(screen.getByPlaceholderText('john@example.com'), 'jane@example.com')
+    await userEvent.type(screen.getByPlaceholderText('********'), 'pass')
+    await userEvent.click(screen.getByRole('button', { name: /sign up/i }))
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(API_PATHS.AUTH.REGISTER, {
+      name: 'Jane Doe',
+      email: 'jane@example.com',
+      password: 'pass',
+      profileImageUrl: '',
+    })
+    expect(updateUser).toHaveBeenCalledWith({ token: 't', name: 'Jane' })
+  })
+
+  it('uploads image when selected', async () => {
+    mockedUpload.mockResolvedValue({ imageUrl: 'img.png' })
+    mockedAxios.post.mockResolvedValue({ data: { token: 'z', name: 'Jane' } })
+    const updateUser = vi.fn()
+
+    render(
+      <BrowserRouter>
+        <UserContext.Provider value={{ user: null, loading: false, updateUser, clearUser: vi.fn() }}>
+          <SignUp setCurrentPage={() => {}} />
+        </UserContext.Provider>
+      </BrowserRouter>,
+    )
+
+    const file = new File(['1'], 'a.png', { type: 'image/png' })
+    await userEvent.upload(screen.getByTestId('photo-input'), file)
+    await userEvent.type(screen.getByPlaceholderText('John Doe'), 'Jane Doe')
+    await userEvent.type(screen.getByPlaceholderText('john@example.com'), 'jane@example.com')
+    await userEvent.type(screen.getByPlaceholderText('********'), 'pass')
+    await userEvent.click(screen.getByRole('button', { name: /sign up/i }))
+
+    expect(mockedUpload).toHaveBeenCalledWith(file)
+    expect(mockedAxios.post).toHaveBeenCalledWith(API_PATHS.AUTH.REGISTER, expect.objectContaining({
+      profileImageUrl: 'img.png',
+    }))
+  })
+})

--- a/src/utils/tests/UploadImage.test.ts
+++ b/src/utils/tests/UploadImage.test.ts
@@ -1,0 +1,21 @@
+import uploadImage from '../UploadImage'
+import { API_PATHS } from '../apiPaths'
+import axiosInstance from '../axiosInstance'
+import { vi } from 'vitest'
+
+vi.mock('../axiosInstance')
+
+const mockedAxios = vi.mocked(axiosInstance)
+
+describe('uploadImage', () => {
+  it('posts form data to upload endpoint', async () => {
+    mockedAxios.post.mockResolvedValue({ data: 'ok' })
+    const file = new File(['1'], 'a.png', { type: 'image/png' })
+    const data = await uploadImage(file)
+    expect(mockedAxios.post).toHaveBeenCalled()
+    const call = mockedAxios.post.mock.calls[0]
+    expect(call[0]).toBe(API_PATHS.IMAGE.UPLOAD_IMAGE)
+    expect(call[1] instanceof FormData).toBe(true)
+    expect(data).toBe('ok')
+  })
+})


### PR DESCRIPTION
## Summary
- configure Cypress for e2e testing
- cover sign-up, dashboard, session creation and interview prep flows
- add npm script to run Cypress

## Testing
- `npx vitest run`
- `npm run test:e2e` *(fails: cypress not found)*

------
https://chatgpt.com/codex/tasks/task_e_685927201318832899c0cfd9f6937d1b