### PR TITLE
Add backend link docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Base URL of the backend API
+VITE_API_BASE_URL=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist
 dist-ssr
 *.local
 .env*
+!.env.example
 
 # Editor directories and files
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -73,3 +73,14 @@ End-to-end tests are executed with Cypress. Ensure the development server is run
 ```bash
 npm run test:e2e
 ```
+
+## Environment Variables
+
+The frontend expects the backend base URL to be provided via the `VITE_API_BASE_URL` environment variable. Create a `.env` file by copying `.env.example` and adjust the value to match your backend server:
+
+```bash
+cp .env.example .env
+echo "VITE_API_BASE_URL=http://localhost:3000" >> .env  # update with your backend URL
+```
+
+The application will use this value for all API requests.


### PR DESCRIPTION
## Summary
- document environment variable for the backend API
- include example `.env` file
- allow `.env.example` in gitignore

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e9bd65660832891814fb1bf072e30